### PR TITLE
Parallelize fetching

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -51,7 +51,7 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyN
 	kingpin.FatalIfError(err, "")
 
 	kingpin.FatalIfError(
-		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".tmp"), os.ModePerm),
+		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".cache"), os.ModePerm),
 		"creating vendor folder")
 
 	if len(uris) > 1 && legacyName != "" {

--- a/cmd/jb/update.go
+++ b/cmd/jb/update.go
@@ -39,7 +39,7 @@ func updateCommand(dir, jsonnetHome string, uris []string) int {
 	kingpin.FatalIfError(err, "failed to load lockfile")
 
 	kingpin.FatalIfError(
-		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".tmp"), os.ModePerm),
+		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".cache"), os.ModePerm),
 		"creating vendor folder")
 
 	locks := lockFile.Dependencies

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -19,8 +19,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -187,9 +185,7 @@ var (
 func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (string, error) {
 	destPath := path.Join(dir, name)
 
-	pkgh := sha256.Sum256([]byte(fmt.Sprintf("jsonnetpkg-%s-%s", strings.Replace(name, "/", "-", -1), strings.Replace(version, "/", "-", -1))))
-	// using 16 bytes should be a good middle ground between length and collision resistance
-	tmpDir, err := ioutil.TempDir(filepath.Join(dir, ".tmp"), hex.EncodeToString(pkgh[:16]))
+	tmpDir, err := os.MkdirTemp(dir, ".tmp-")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create tmp dir")
 	}

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -91,9 +91,7 @@ func Ensure(direct v1.JsonnetFile, vendorDir string, oldLocks *deps.Ordered) (*d
 			if err := os.RemoveAll(dir); err != nil {
 				return nil, err
 			}
-			if !strings.HasPrefix(name, ".tmp") {
-				color.Magenta("CLEAN %s", dir)
-			}
+			color.Magenta("CLEAN %s", dir)
 		}
 	}
 

--- a/pkg/parallel.go
+++ b/pkg/parallel.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"sync"
 
@@ -99,12 +98,11 @@ func (pd *parallelDownloader) ensure(direct *deps.Ordered, vendorDir, pathToPare
 			}
 
 			if needsDownload {
-				// TODO compat with download() code. can be simplified
 				if err := os.RemoveAll(cp); err != nil {
 					pd.addErr(err)
 					return
 				}
-				if err := os.MkdirAll(path.Join(cp, ".tmp"), os.ModePerm); err != nil {
+				if err := os.MkdirAll(cp, os.ModePerm); err != nil {
 					pd.addErr(err)
 					return
 				}

--- a/pkg/parallel.go
+++ b/pkg/parallel.go
@@ -1,0 +1,212 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
+	v1 "github.com/jsonnet-bundler/jsonnet-bundler/spec/v1"
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
+)
+
+func downloadAndLink(direct v1.JsonnetFile, vendorDir string, oldLocks *deps.Ordered) (*deps.Ordered, error) {
+	dl, err := new(parallelDownloader).Ensure(direct.Dependencies, vendorDir, "", oldLocks)
+	if err != nil {
+		return nil, err
+	}
+
+	return oldLocks, linkDownloaded(direct.Dependencies, vendorDir, dl, oldLocks, make(map[string]struct{}))
+}
+
+type packageRef struct {
+	name    string
+	version string
+}
+
+type downloadedPackage struct {
+	lock deps.Dependency
+	jsf  *v1.JsonnetFile
+}
+
+// parallelDownloader is a downloader that downloads all dependencies in parallel
+// The zero parallelDownloader is empty and ready for use. Must not be copied after first use.
+// Should not be used after calling Ensure.
+type parallelDownloader struct {
+	// seen stores the packages that we are already working on
+	seen sync.Map
+	// stores how many goroutines are still working
+	working sync.WaitGroup
+
+	// deps stores all dependencies that we have already downloaded
+	locksM sync.Mutex
+	locks  map[packageRef]downloadedPackage
+
+	// errs stores all errors that occured during the download
+	errsM sync.Mutex
+	errs  []error
+}
+
+// Ensure recursively downloads all dependencies of the given direct dependencies.
+// If a download already exists it is integrity checked and skipped if it is valid.
+// Integrity is checked by comparing the sha256 checksum of the downloaded files with the one in the lock.
+// It returns a map of all downloaded packages and their locks.
+// If an error occurs, the map might be incomplete.
+// If the same package is requested multiple times, it is only downloaded once.
+// The parallelDownloader must be discarded after calling Ensure.
+func (pd *parallelDownloader) Ensure(direct *deps.Ordered, vendorDir, pathToParentModule string, oldLocks *deps.Ordered) (map[packageRef]downloadedPackage, error) {
+	pd.ensure(direct, vendorDir, "", oldLocks)
+	pd.working.Wait()
+	return pd.locks, errors.Join(pd.errs...)
+}
+
+// ensure recursively downloads all dependencies of the given direct dependencies.
+// It spawns goroutines for all dependencies and does not wait for the goroutines to finish.
+// Callers should call pd.working.Wait() to wait for all goroutines to finish.
+// Stores all downloaded packages in pd.locks and all errors in pd.errs.
+func (pd *parallelDownloader) ensure(direct *deps.Ordered, vendorDir, pathToParentModule string, oldLocks *deps.Ordered) {
+	for _, k := range direct.Keys() {
+		pd.working.Add(1)
+		go func(k string) {
+			defer pd.working.Done()
+			d, _ := direct.Get(k)
+
+			ref := packageRef{name: d.Name(), version: d.Version}
+			// Skip if we are already working on this package
+			_, seen := pd.seen.LoadOrStore(ref, struct{}{})
+			if seen {
+				return
+			}
+
+			cp := cachePath(vendorDir, d)
+			needsDownload := true
+			expectedSum := ""
+
+			lock, present := oldLocks.Get(d.Name())
+			if present {
+				// if in lock file and the integrity is intact, no need to download
+				if check(lock, cp) {
+					needsDownload = false
+				}
+				// we should use the resolved version from the lock file
+				// e.g. master -> 0b2ab31b77f0ede56b660850462ff279eadcd50c
+				d.Version = lock.Version
+				expectedSum = lock.Sum
+			}
+
+			if needsDownload {
+				// TODO compat with download() code. can be simplified
+				if err := os.RemoveAll(cp); err != nil {
+					pd.addErr(err)
+					return
+				}
+				if err := os.MkdirAll(path.Join(cp, ".tmp"), os.ModePerm); err != nil {
+					pd.addErr(err)
+					return
+				}
+				l, err := download(d, cp, pathToParentModule)
+				if err != nil {
+					pd.addErr(err)
+					return
+				}
+				if expectedSum != "" && expectedSum != l.Sum {
+					pd.addErr(fmt.Errorf("integrity check failed for %s@%s", d.Name(), d.Version))
+					return
+				}
+				lock = *l
+			}
+
+			if d.Single {
+				// skip dependencies that explicitely don't want nested ones installed
+				pd.addLock(ref, downloadedPackage{lock: lock})
+				return
+			}
+
+			// load jsonnetfile from the package and recursively download dependencies
+			f, err := jsonnetfile.Load(filepath.Join(cp, d.Name(), jsonnetfile.File))
+			if err != nil {
+				if os.IsNotExist(err) {
+					pd.addLock(ref, downloadedPackage{lock: lock})
+					return
+				}
+				pd.addErr(err)
+				return
+			}
+			pd.addLock(ref, downloadedPackage{lock: lock, jsf: &f})
+
+			absolutePath, err := filepath.EvalSymlinks(filepath.Join(cp, d.Name()))
+			if err != nil {
+				pd.addErr(err)
+				return
+			}
+
+			pd.ensure(f.Dependencies, vendorDir, absolutePath, oldLocks)
+		}(k)
+	}
+}
+
+func (pd *parallelDownloader) addLock(p packageRef, d downloadedPackage) {
+	pd.locksM.Lock()
+	defer pd.locksM.Unlock()
+	if pd.locks == nil {
+		pd.locks = make(map[packageRef]downloadedPackage)
+	}
+	pd.locks[p] = d
+}
+
+func (pd *parallelDownloader) addErr(err error) {
+	pd.errsM.Lock()
+	defer pd.errsM.Unlock()
+	pd.errs = append(pd.errs, err)
+}
+
+func cachePath(vendorDir string, d deps.Dependency) string {
+	return filepath.Join(vendorDir, ".cache", url.PathEscape(d.Name()+"-"+d.Version))
+}
+
+// linkDownloaded recursively links all downloaded packages into the vendor directory.
+// It also deterministically adds the downloaded packages to the locks.
+// The first seen packages version is used as the lock version.
+func linkDownloaded(direct *deps.Ordered, vendorDir string, downloaded map[packageRef]downloadedPackage, oldLocks *deps.Ordered, seen map[string]struct{}) error {
+	for _, k := range direct.Keys() {
+		d, _ := direct.Get(k)
+		// skip if we already linked and locked this package
+		if _, ok := seen[d.Name()]; ok {
+			continue
+		}
+		seen[d.Name()] = struct{}{}
+
+		// check cache if we downloaded this package
+		// it should always be present
+		dl, ok := downloaded[packageRef{name: d.Name(), version: d.Version}]
+		if !ok {
+			return fmt.Errorf("could not find downloaded package %s@%s", d.Name(), d.Version)
+		}
+		oldLocks.Set(d.Name(), dl.lock)
+
+		// link the package into the vendor directory
+		dest := filepath.Join(vendorDir, d.Name())
+		if err := os.RemoveAll(dest); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
+			return err
+		}
+		if err := os.Symlink(filepath.Join(cachePath(vendorDir, d), d.Name()), dest); err != nil {
+			return err
+		}
+
+		if dl.jsf == nil {
+			continue
+		}
+
+		// if the package has a jsonnetfile, recursively link and lock its dependencies
+		linkDownloaded(dl.jsf.Dependencies, vendorDir, downloaded, oldLocks, seen)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Builds on top of the introduced deterministic dependency resolution.
- Parallelises downloads and integrity checks by downloading dependencies into  `vendor/.cache` and deterministically symlinks them in a second step.
- Adds some debug output where errors where previously ignored or forgotten.

