### PR TITLE
Delay throwing download error until we know package is required

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -225,10 +225,10 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 				// Move the extracted directory to its final destination
 				if err == nil {
 					if err := os.MkdirAll(filepath.Dir(destPath), os.ModePerm); err != nil {
-						panic(err)
+						return "", fmt.Errorf("failed to create parent path: %s", err)
 					}
 					if err := os.Rename(path.Join(tmpDir, p.Source.Subdir), destPath); err != nil {
-						panic(err)
+						return "", fmt.Errorf("failed to move package: %s; was the sub dir moved?", err)
 					}
 				}
 			}


### PR DESCRIPTION
Not all downloaded packages are required after walking the dependency tree in the link stage.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
