### PR TITLE
Retry Git ref resolution with `main` if `master` resolves to empty string

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -198,6 +198,11 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		// Let git ls-remote decide if "version" is a ref or a commit SHA in the unlikely
 		// but possible event that a ref is comprised of 40 or more hex characters
 		commitSha, err := remoteResolveRef(ctx, p.Source.Remote(), version)
+		if commitSha == "" && version == "master" {
+			color.Yellow("WARN: ref 'master' resolved to empty string for %s, retrying with 'main'", p.Source.Remote())
+			version = "main"
+			commitSha, err = remoteResolveRef(ctx, p.Source.Remote(), version)
+		}
 		if err != nil {
 			color.White("failed to resolve ref %s@%s: %s", name, version, err)
 		}


### PR DESCRIPTION
## Summary

This allows us to work around issues that stem from Red Hat renaming the default branch of some of their repos to `main` until Red Hat's Jsonnet libraries are updated to use the new default branch name.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
