### PR TITLE
Fix `--version` flag for released binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PKGS=$(shell go list ./... | grep -v /vendor/)
 all: check-license build generate test
 
 # Binaries
-LDFLAGS := '-s -w -extldflags "-static" -X main.Version=${VERSION}'
+LDFLAGS := '-s -w -extldflags "-static" -X main.version=${VERSION}'
 cross: clean
 	CGO_ENABLED=0 gox \
 	  -output="$(OUT_DIR)/jb-{{.OS}}-{{.Arch}}" \

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -33,7 +33,7 @@ const (
 	rewriteActionName = "rewrite"
 )
 
-var Version = "dev"
+var version = "dev"
 
 func main() {
 	os.Exit(Main())
@@ -46,7 +46,7 @@ func Main() int {
 
 	color.Output = color.Error
 
-	a := kingpin.New(filepath.Base(os.Args[0]), "A jsonnet package manager").Version(Version)
+	a := kingpin.New(filepath.Base(os.Args[0]), "A jsonnet package manager").Version(version)
 	a.HelpFlag.Short('h')
 
 	a.Flag("jsonnetpkg-home", "The directory used to cache packages in.").


### PR DESCRIPTION
## Summary

Goreleaser sets `main.version` to the version that's being released (cf. https://goreleaser.com/cookbooks/using-main.version/). We adjust the code and Makefile to also use `main.version` instead of `main.Version` so we actually get the real built version for the released binaries.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
